### PR TITLE
Fix daily crawler: bypass Cloudflare via Ferrum (depends on relaton-cie#15)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
-gem 'relaton-cie', github: 'relaton/relaton-cie', branch: 'lutaml-integration'
+gem 'relaton-cie', github: 'relaton/relaton-cie', branch: 'fix/ferrum-cloudflare-bypass'


### PR DESCRIPTION
## Summary

- Pin Gemfile at `relaton/relaton-cie:fix/ferrum-cloudflare-bypass` so the daily Crawler workflow exercises the headless-Chrome (Ferrum) fix proposed upstream in [relaton/relaton-cie#15](https://github.com/relaton/relaton-cie/pull/15).
- This PR is a CI smoke test against a live external service (Cloudflare-protected `store.accuristech.com`). Once relaton-cie#15 merges into `lutaml-integration`, this Gemfile pin is reverted back to `lutaml-integration` (no version bump needed; bundle update will pick up the new SHA).

## Why

`Crawler` has been failing every scheduled run since at least June 2025 (~11 months): see [run 25811453861](https://github.com/relaton/relaton-data-cie/actions/runs/25811453861/job/75828571768). Root cause is Cloudflare Turnstile on `store.accuristech.com` (Techstreet's successor); plain HTTP clients receive HTTP 403 regardless of User-Agent. Empirically verified that headless Chrome with standard stealth tweaks clears the challenge and yields the real HTML.

## Test plan

- [ ] CI run on this PR clears the Crawler workflow with a non-empty diff under `data/`.
- [ ] After merging upstream, revert pin to `lutaml-integration` and confirm next scheduled run is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)